### PR TITLE
Move compiler #if statement to top of file.

### DIFF
--- a/BranchUnityTestBed/Assets/Branch/Editor/BranchPostProcessBuild.cs
+++ b/BranchUnityTestBed/Assets/Branch/Editor/BranchPostProcessBuild.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+#if UNITY_IOS
+
+using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using System.Collections;
@@ -8,7 +10,6 @@ using System.Text;
 using System.Xml;
 using System.IO;
 
-#if UNITY_IOS
 public class BranchPostProcessBuild {
 
 	[PostProcessBuild(900)]


### PR DESCRIPTION
- Unity gives a compilation error on some versions when including UnityEditor.iOS.Xcode if IOS target is not installed.

reference: https://issuetracker.unity3d.com/issues/ios-monodevelop-unityeditor-dot-ios-dot-xcode-namespace-isnt-recognised-in-monodevelop