### PR TITLE
Fix linux editor string splitting

### DIFF
--- a/BranchUnityTestBed/Assets/Branch/Editor/BranchEditor.cs
+++ b/BranchUnityTestBed/Assets/Branch/Editor/BranchEditor.cs
@@ -109,7 +109,7 @@ public class BranchEditor : Editor {
 
 		StreamReader sr = new StreamReader(iosWrapperPath, Encoding.Default);
         
-		#if UNITY_EDITOR_OSX
+		#if UNITY_EDITOR_OSX || UNITY_EDITOR_LINUX
 		string[] lines = sr.ReadToEnd().Split(new string[] { System.Environment.NewLine }, System.StringSplitOptions.None).ToArray();
 		#elif UNITY_EDITOR_WIN
 		string[] lines = sr.ReadToEnd().Split(new string[] { "\r\n", "\n", "\r" }, System.StringSplitOptions.None).ToArray();


### PR DESCRIPTION
BranchEditor had conditional compilation for handling newlines for UNITY_EDITOR_OSX and UNITY_EDITOR_WIN, but not UNITY_EDITOR_LINUX. The solution here is to have the Linux editor use the same code path as the OSX editor, as both systems treat newlines the same way.

This change has been already in production at my workplace for over a year without any issues, so I'm quite confident that it does not cause any problems.