### PR TITLE
INTENG-20830 - Not able to setup Facebook App ID through Unity SDK

### DIFF
--- a/BranchUnityTestBed/Assets/Branch/Branch.cs
+++ b/BranchUnityTestBed/Assets/Branch/Branch.cs
@@ -149,6 +149,14 @@ public class Branch : MonoBehaviour {
     }
 
     /**
+     * Specifiy a Facebook ID for the current session.
+     */
+    public static void setFBAppID(string facebookAppID)
+    {
+	    _setFBAppID(facebookAppID);
+    }
+
+    /**
      * Specifiy an identity for the current session and receive information about the set.
      */
     public static void setIdentity(string userId, BranchCallbackWithParams callback) {
@@ -456,6 +464,10 @@ public class Branch : MonoBehaviour {
     private static void _setIdentity(string userId) {
         BranchAndroidWrapper.setIdentity(userId);
     }
+
+	private static void _setFBAppID(string facebookAppID){
+        BranchAndroidWrapper.setFBAppID(facebookAppID);
+	}
     
     private static void _setIdentityWithCallback(string userId, string callbackId) {
         BranchAndroidWrapper.setIdentityWithCallback(userId, callbackId);
@@ -526,6 +538,8 @@ public class Branch : MonoBehaviour {
 	}
 
 #else
+
+	private static void _setFBAppID(string facebookAppID){ }
 
 	private static void _setBranchKey(string branchKey, string sdkVersion) { }
 

--- a/BranchUnityTestBed/Assets/Branch/BranchAndroidWrapper.cs
+++ b/BranchUnityTestBed/Assets/Branch/BranchAndroidWrapper.cs
@@ -57,6 +57,14 @@ public class BranchAndroidWrapper {
         	_getBranchClass().CallStatic("setIdentity", userId);
 		});
     }
+
+    //INTENG-20830
+    public static void setFBAppID(string facebookAppID)
+    {
+	    _runBlockOnThread(() => {
+		    _getBranchClass().CallStatic("setFBAppID", facebookAppID);
+	    });
+    }
     
     public static void setIdentityWithCallback(string userId, string callbackId) {
 		_runBlockOnThread(() => {


### PR DESCRIPTION
## Reference
INTENG-20830 -- [Multiple] Not able to setup Facebook App ID through Unity SDK

## Summary
Adding frontend C# code to set Facebook App ID for Meta install referrer functionality.

Branch.cs
`    /**
     * Specifiy a Facebook ID for the current session.
     */
    public static void setFBAppID(string facebookAppID)
    {
	    _setFBAppID(facebookAppID);
    }
`

BranchAndroidWrapper.cs

`    //INTENG-20830
    public static void setFBAppID(string facebookAppID)
    {
	    _runBlockOnThread(() => {
		    _getBranchClass().CallStatic("setFBAppID", facebookAppID);
	    });
    }
`



## Motivation
Facebook requires the Facebook App ID to enable Meta install referrer, without this any kind of raw data format will not be able to be shown from every party.

Please advise that install referrer only works with Android, and will not work with the iOS. - Following the limitation from the Meta side. 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Testing Instructions
- add `Branch.setFBAppID("");` before the initialization.
- From the Gateway check if we have got the FBAppID from the SDK log.


cc @BranchMetrics/saas-sdk-devs for visibility.
