### PR TITLE
[SECBUG-167] Update image URL to new AWS S3 location in us-west-2

### DIFF
--- a/BranchUnityTestBed/Assets/Branch/Demo/Scripts/BranchDemo.cs
+++ b/BranchUnityTestBed/Assets/Branch/Demo/Scripts/BranchDemo.cs
@@ -91,7 +91,7 @@ public class BranchDemo : MonoBehaviour {
 			universalObject.canonicalUrl = "https://branch.io";
 			universalObject.title = "id12345 title";
 			universalObject.contentDescription = "My awesome piece of content!";
-			universalObject.imageUrl = "https://s3-us-west-1.amazonaws.com/branchhost/mosaic_og.png";
+			universalObject.imageUrl = "https://s3-us-west-2.amazonaws.com/branchhost-usw2/mosaic_og.png";
 			universalObject.contentIndexMode = 0;
 			universalObject.localIndexMode = 0;
 			universalObject.expirationDate = new DateTime(2020, 12, 30);
@@ -113,7 +113,7 @@ public class BranchDemo : MonoBehaviour {
 			universalObject.metadata.setLocation(40.0f, 40.0f);
 			universalObject.metadata.setRating(4.0f, 5.0f, 10);
 
-			universalObject.metadata.AddImageCaption("https://s3-us-west-1.amazonaws.com/branchhost/mosaic_og.png");
+			universalObject.metadata.AddImageCaption("https://s3-us-west-2.amazonaws.com/branchhost-usw2/mosaic_og.png");
 			universalObject.metadata.AddCustomMetadata("foo", "bar");
 
 


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/SECBUG-167

## Summary
`branchhost` s3 bucket in us-west-1 was terminated long ago as part of the Oregon Trail cleanup project. This PR removes the stale reference to address a security vulnerability as described the by the relevant bug bounty ticket.

## Motivation
Provided in the above summary.

## Type Of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
N/A

cc @BranchMetrics/saas-sdk-devs for visibility.
