### PR TITLE
[SECBUG-167] Update the asset S3 URL from legacy style to virtual host style

### DIFF
--- a/BranchUnityTestBed/Assets/Branch/Demo/Scripts/BranchDemo.cs
+++ b/BranchUnityTestBed/Assets/Branch/Demo/Scripts/BranchDemo.cs
@@ -91,7 +91,7 @@ public class BranchDemo : MonoBehaviour {
 			universalObject.canonicalUrl = "https://branch.io";
 			universalObject.title = "id12345 title";
 			universalObject.contentDescription = "My awesome piece of content!";
-			universalObject.imageUrl = "https://s3-us-west-2.amazonaws.com/branchhost-usw2/mosaic_og.png";
+			universalObject.imageUrl = "https://branchhost-usw2.s3.us-west-2.amazonaws.com/mosaic_og.png";
 			universalObject.contentIndexMode = 0;
 			universalObject.localIndexMode = 0;
 			universalObject.expirationDate = new DateTime(2020, 12, 30);
@@ -113,7 +113,7 @@ public class BranchDemo : MonoBehaviour {
 			universalObject.metadata.setLocation(40.0f, 40.0f);
 			universalObject.metadata.setRating(4.0f, 5.0f, 10);
 
-			universalObject.metadata.AddImageCaption("https://s3-us-west-2.amazonaws.com/branchhost-usw2/mosaic_og.png");
+			universalObject.metadata.AddImageCaption("https://branchhost-usw2.s3.us-west-2.amazonaws.com/mosaic_og.png");
 			universalObject.metadata.AddCustomMetadata("foo", "bar");
 
 


### PR DESCRIPTION
## Reference
[SECBUG-167](https://branch.atlassian.net/browse/SECBUG-167)

## Summary
Upgrade the S3 asset URL from legacy path-style endpoint to virtual-hosted style as per doc recommendation.

## Motivation
Mentioned above.

## Type Of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
N/A

cc @BranchMetrics/saas-sdk-devs for visibility.


[SECBUG-167]: https://branch.atlassian.net/browse/SECBUG-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ